### PR TITLE
Pretty addresses

### DIFF
--- a/.idea/dictionaries/ohadperry.xml
+++ b/.idea/dictionaries/ohadperry.xml
@@ -1,0 +1,8 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="ohadperry">
+    <words>
+      <w>blockchain</w>
+      <w>blockchains</w>
+    </words>
+  </dictionary>
+</component>

--- a/.idea/runConfigurations/final_web_server_3000_node_id_2563fc0e_5128_4ee2_b08d_f0de0e986b8d_for_consistency_.xml
+++ b/.idea/runConfigurations/final_web_server_3000_node_id_2563fc0e_5128_4ee2_b08d_f0de0e986b8d_for_consistency_.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="final web server 3000 node id 2563fc0e-5128-4ee2-b08d-f0de0e986b8d for consistency " type="NodeJSConfigurationType" factoryName="Node.js" application-parameters="--port 3000 --id 2563fc0e-5128-4ee2-b08d-f0de0e986b8d" path-to-js-file="dist/final.js" working-dir="$PROJECT_DIR$">
+    <method />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -19,3 +19,17 @@ Blockchain academy was founded by top tier professionals that have been actively
 ## License
 
 [MIT](LICENSE)
+
+
+## Initial setup
+
+```
+npm install -g ts-node
+npm install -g typescript-compiler
+
+compile using
+tsc
+or
+npm run build 
+
+```

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   "license": "MIT",
   "homepage": "https://github.com/lbeder/blockchain-academy-how-build-your-own-blockchain#readme",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "echo \"running build using tsc\" && tsc",
+    "compile": "npm run build",
+    "pretty_name_scenario": "cd src; ./14_pretty_name_addresses.sh"
   },
   "dependencies": {
     "@types/axios": "^0.14.0",

--- a/src/14_pretty_name_addresses.sh
+++ b/src/14_pretty_name_addresses.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+bold=$(tput bold)
+
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+
+reset=$(tput sgr0)
+
+trap "exit" INT TERM ERR
+trap "kill 0" EXIT
+
+# rebuild the distribution
+npm run build
+
+./cleanslate.sh
+
+# Start the node.
+NODE1="test"
+NODE1_PORT=3000
+NODE1_URL="http://localhost:${NODE1_PORT}"
+
+node ../dist/final.js --port=${NODE1_PORT} --id=${NODE1} &
+
+sleep 2
+
+# adding 2 addresses
+echo -e && read -n 1 -s -r -p "${bold}${green}✔ Adding 2 addresses that will serve as receiver and sender. Press any key to continue...${reset}" && echo -e
+
+curl -X PUT -H "Content-Type: application/json" -d '{
+ "prettyName": "ohads-personal"
+}' "${NODE1_URL}/address" -w "\n"
+
+curl -X PUT -H "Content-Type: application/json" -d '{
+ "prettyName": "ohads-business"
+}' "${NODE1_URL}/address" -w "\n"
+
+
+# Submit 2 transactions to the first node.
+echo -e && read -n 1 -s -r -p "${bold}${green}✔ Submitting 2 valid transactions. Press any key to continue...${reset}" && echo -e
+
+curl -X POST -H "Content-Type: application/json" -d '{
+ "senderPrettyName": "ohads-personal",
+ "recipientPrettyName": "ohads-business",
+ "value": "100"
+}' "${NODE1_URL}/transactions" -w "\n"
+
+curl -X POST -H "Content-Type: application/json" -d '{
+ "senderPrettyName": "ohads-business",
+ "recipientPrettyName": "ohads-personal",
+ "value": "50"
+}' "${NODE1_URL}/transactions" -w "\n"
+
+
+echo -e && read -n 1 -s -r -p "${bold}${green}✔ now adding a non valid transaction to a fake-address, EXPECTING AN ERROR. Press any key to continue...${reset}" && echo -e
+
+curl -X POST -H "Content-Type: application/json" -d '{
+ "senderPrettyName": "fake-address",
+ "recipientPrettyName": "ohads-business",
+ "value": "100"
+}' "${NODE1_URL}/transactions" -w "\n"
+
+echo -e && read -n 1 -s -r -p "${bold}${green}✔ now adding a non valid transaction to from an address to itself, EXPECTING AN ERROR. Press any key to continue...${reset}" && echo -e
+
+curl -X POST -H "Content-Type: application/json" -d '{
+ "senderPrettyName": "ohads-business",
+ "recipientPrettyName": "ohads-business",
+ "value": "50"
+}' "${NODE1_URL}/transactions" -w "\n"
+
+
+
+# Mine 1 block.
+echo -e && read -n 1 -s -r -p "${bold}${green}✔ Mining blocks to make sure we didn't break anything. Press any key to continue...${reset}" && echo -e
+
+curl -X POST -H "Content-Type: application/json" "${NODE1_URL}/blocks/mine" -w "\n"
+
+
+echo "${bold}${green}✔ done. happy.${reset}"


### PR DESCRIPTION
# **Pretty addresses**!!

@lbeder submitting my humble suggestion. 
TD;LR - adding addresses to the blockchain with an option to use pretty names to be more user-friendly. 
I'm guessing most users won't mind replacing their long, 34 characters, with a nickname. 
instead of saying send it to `1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2` you can say send it to `opmaster`

This feature will probably be most useful in private chains. 





More ideas:
- validate address is legal 
- validate unspent transactions to make sure the address has enough to send
- compress the storage saved to save time
- use caching and indexing for performance

